### PR TITLE
fix tram not showing issue + other improvements

### DIFF
--- a/full.liquid
+++ b/full.liquid
@@ -8,26 +8,20 @@
 <div class="layout layout--top">
   <div class="stretch-y">
     <table class="table table--bordered table--compact">
-      <thead>
-        <tr>
-          <th><span class="label label--bold">Time</span></th>
-          <th><span class="label label--bold">Direction</span></th>
-          <th><span class="label label--bold">Platform</span></th>
-          <th><span class="label label--bold">Delay</span></th>
-          <th><span class="label label--bold">Line</span></th>
-        </tr>
-      </thead>
+        {% render "full_header" %}
       <tbody>
+        {% assign count = 0 %}
         {% for item in departures %}
-        {% assign mode = item.line.productName %}
+        {% assign mode = item.line.productName | slice: 0 %}
         {% if preferred_modes_raw contains mode %}
         {% assign delay_minutes = item.delay | divided_by: 60 %}
+        {% assign count = count | plus: 1 %}
         <tr>
           <td><span class="label">{{ item.plannedWhen | date: "%H:%M" }}</span></td>
           <td><span class="label">{{ item.direction }}</span></td>
           <td>
             <span class="label">
-              {% if item.cancelled == true or mode == 'Bus' %}
+              {% if item.cancelled == true or mode == 'B' %}
               -
               {% else %}
               {{ item.platform }}
@@ -35,22 +29,36 @@
             </span>
           </td>
           <td>
-            {% if item.delay > 0 %}
-            <span class="label label--inverted">+{{ delay_minutes }}m</span>
-            {% elsif item.delay < 0 %}
-              <span class="label label--inverted">{{ delay_minutes }}m</span>
+            <span class="label">
+              {% for remark in item.remarks %}
+                {% if remark.type == "warning" %}
+                  <img class="image" src="https://img.icons8.com/ios/25/error.png"/>
+                  {% break %}
+                {% endif %}
+              {% endfor %}
+            </span>
+          </td>
+          <td>
+            {% if item.cancelled == true %}
+              <span class="label label--inverted text--center">Cancelled</span>
+            {% else %}
+              {% if item.delay > 0 %}
+                <span class="label label--inverted text--center">+{{ delay_minutes }}m</span>
+              {% elsif item.delay < 0 %}
+                <span class="label label--inverted text--center">{{ delay_minutes }}m</span>
               {% else %}
-              <span class="label">On time</span>
+                <span class="label">On time</span>
               {% endif %}
+            {% endif %}
           </td>
           <td>
             <span class="label">
-              {% case item.line.productName %}
+              {% case mode %}
               {% when "T" %}
               <img class="image" src="https://img.icons8.com/ios/25/tram.png"/>
               {% when "U" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/subway.png"/>
-              {% when "Bus" %}
+              {% when "B" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/bus.png"/>
               {% else %}
               <img class="image" src="https://img.icons8.com/ios/25/train.png"/>
@@ -59,6 +67,9 @@
             </span>
           </td>
         </tr>
+        {% endif %}
+        {% if count == 8 %}
+            {% break %}
         {% endif %}
         {% endfor %}
       </tbody>

--- a/half_horizontal.liquid
+++ b/half_horizontal.liquid
@@ -8,26 +8,20 @@
 <div class="layout layout--top">
   <div class="stretch-y">
     <table class="table table--bordered table--compact">
-      <thead>
-        <tr>
-          <th><span class="label label--bold">Time</span></th>
-          <th><span class="label label--bold">Direction</span></th>
-          <th><span class="label label--bold">Platform</span></th>
-          <th><span class="label label--bold">Delay</span></th>
-          <th><span class="label label--bold">Line</span></th>
-        </tr>
-      </thead>
+      {% render "full_header" %}
       <tbody>
-        {% for item in departures limit: 4 %}
-        {% assign mode = item.line.productName %}
+        {% assign count = 0 %}
+        {% for item in departures %}
+        {% assign mode = item.line.productName | slice: 0 %}
         {% if preferred_modes_raw contains mode %}
         {% assign delay_minutes = item.delay | divided_by: 60 %}
+        {% assign count = count | plus: 1 %}
         <tr>
           <td><span class="label">{{ item.plannedWhen | date: "%H:%M" }}</span></td>
           <td><span class="label">{{ item.direction }}</span></td>
           <td>
             <span class="label">
-              {% if item.cancelled == true or mode == 'Bus' %}
+              {% if item.cancelled == true or mode == 'B' %}
               -
               {% else %}
               {{ item.platform }}
@@ -35,17 +29,31 @@
             </span>
           </td>
           <td>
-            {% if item.delay > 0 %}
-            <span class="label label--inverted">+{{ delay_minutes }}m</span>
-            {% elsif item.delay < 0 %}
-              <span class="label label--inverted">{{ delay_minutes }}m</span>
+            <span class="label">
+              {% for remark in item.remarks %}
+                {% if remark.type == "warning" %}
+                  <img class="image" src="https://img.icons8.com/ios/25/error.png"/>
+                  {% break %}
+                {% endif %}
+              {% endfor %}
+            </span>
+          </td>
+          <td>
+            {% if item.cancelled == true %}
+              <span class="label label--inverted text--center">Cancelled</span>
+            {% else %}
+              {% if item.delay > 0 %}
+                <span class="label label--inverted text--center">+{{ delay_minutes }}m</span>
+              {% elsif item.delay < 0 %}
+                <span class="label label--inverted text--center">{{ delay_minutes }}m</span>
               {% else %}
-              <span class="label">On time</span>
+                <span class="label">On time</span>
               {% endif %}
+            {% endif %}
           </td>
           <td>
             <span class="label">
-              {% case item.line.productName %}
+              {% case mode %}
               {% when "T" %}
               <img class="image" src="https://img.icons8.com/ios/25/tram.png"/>
               {% when "U" %}
@@ -59,6 +67,9 @@
             </span>
           </td>
         </tr>
+        {% endif %}
+        {% if count == 4 %}
+            {% break %}
         {% endif %}
         {% endfor %}
       </tbody>

--- a/half_vertical.liquid
+++ b/half_vertical.liquid
@@ -8,29 +8,30 @@
 <div class="layout layout--top">
   <div class="stretch-y">
     <table class="table table--bordered table--compact">
-      <thead>
-        <tr>
-          <th><span class="label label--small">Time</span></th>
-          <th><span class="label label--small">Direction</span></th>
-          <th><span class="label label--small">Line</span></th>
-        </tr>
-      </thead>
+      {% render "half_header" %}
       <tbody>
+        {% assign count = 0 %}
         {% for item in departures %}
-        {% assign mode = item.line.productName %}
+        {% assign mode = item.line.productName | slice: 0 %}
         {% if preferred_modes_raw contains mode %}
         {% assign delay_minutes = item.delay | divided_by: 60 %}
+        {% assign count = count | plus: 1 %}
         <tr>
-          <td><span class="label label--small">{{ item.plannedWhen | date: "%H:%M" }}</span></td>
+          <td><span class="label label--small">
+              {{ item.plannedWhen | date: "%H:%M" }}
+              {% if item.cancelled == true %}
+              <img class="image" src="https://img.icons8.com/ios/25/cancel.png" height="13"/>
+              {% endif %}
+          </span></td>
           <td><span class="label label--small">{{ item.direction | truncate: 40 }}</span></td>
           <td>
             <span class="label label--small">
-              {% case item.line.productName %}
+              {% case mode %}
               {% when "T" %}
               <img class="image" src="https://img.icons8.com/ios/25/tram.png" height="13"/>
               {% when "U" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/subway.png" height="13"/>
-              {% when "Bus" %}
+              {% when "B" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/bus.png" height="13"/>
               {% else %}
               <img class="image" src="https://img.icons8.com/ios/25/train.png" height="13"/>
@@ -39,6 +40,9 @@
             </span>
           </td>
         </tr>
+        {% endif %}
+        {% if count == 8 %}
+            {% break %}
         {% endif %}
         {% endfor %}
       </tbody>

--- a/quadrant.liquid
+++ b/quadrant.liquid
@@ -8,29 +8,30 @@
 <div class="layout layout--top">
   <div class="stretch-y">
     <table class="table table--bordered table--compact">
-      <thead>
-        <tr>
-          <th><span class="value value--xxsmall">Time</span></th>
-          <th><span class="value value--xxsmall">Direction</span></th>
-          <th><span class="value value--xxsmall">Line</span></th>
-        </tr>
-      </thead>
+        {% render "half_header" %}
       <tbody>
-        {% for item in departures limit: 4%}
-        {% assign mode = item.line.productName %}
+        {% assign count = 0 %}
+        {% for item in departures %}
+        {% assign mode = item.line.productName | slice: 0 %}
         {% if preferred_modes_raw contains mode %}
         {% assign delay_minutes = item.delay | divided_by: 60 %}
+        {% assign count = count | plus: 1 %}
         <tr>
-          <td><span class="label label--small">{{ item.plannedWhen | date: "%H:%M" }}</span></td>
+            <td><span class="label label--small">
+                {{ item.plannedWhen | date: "%H:%M" }}
+                {% if item.cancelled == true %}
+                <img class="image" src="https://img.icons8.com/ios/25/cancel.png" height="13"/>
+                {% endif %}
+            </span></td>
           <td><span class="label label--small">{{ item.direction | truncate: 40 }}</span></td>
           <td>
             <span class="label label--small">
-              {% case item.line.productName %}
+              {% case mode %}
               {% when "T" %}
               <img class="image" src="https://img.icons8.com/ios/25/tram.png" height="13"/>
               {% when "U" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/subway.png" height="13"/>
-              {% when "Bus" %}
+              {% when "B" %}
               <img class="image" src="https://img.icons8.com/ios-filled/25/bus.png" height="13"/>
               {% else %}
               <img class="image" src="https://img.icons8.com/ios/25/train.png" height="13"/>
@@ -39,6 +40,9 @@
             </span>
           </td>
         </tr>
+        {% endif %}
+        {% if count == 4 %}
+            {% break %}
         {% endif %}
         {% endfor %}
       </tbody>
@@ -51,4 +55,3 @@
   <span class="title">BVG - Berlin </span>
   <span class="instance">{{ "now" | date: '%s' | plus: trmnl.user.utc_offset | date: "%d.%m.%Y %H:%M" }}</span>
 </div>
-

--- a/settings.yml
+++ b/settings.yml
@@ -1,29 +1,29 @@
 ---
 strategy: polling
-no_screen_padding: 'no'
-dark_mode: 'no'
-static_data: ''
+no_screen_padding: "no"
+dark_mode: "no"
+static_data: ""
 polling_verb: get
 polling_url: https://v6.bvg.transport.rest/stops/{{stopId}}/departures?duration=60
-polling_headers: ''
+polling_headers: ""
 id: 39029
 custom_fields:
-- keyname: stopId
-  field_type: string
-  name: Stop ID
-  description: Stop ID from the BVG API.
-  help_text: The Stop ID can be found using the <a href="link-to-api" target="https://v6.bvg.transport.rest/api.html#get-locations" class="underline">locations endpoint</a> of the BVG API.
-  default: 900100003
-- keyname: modes
-  field_type: select
-  name: Preferred Transport Modes
-  help_text: Select which types of transport to show.<br>Hold cmd(⌘) or ctrl to choose multiple options.
-  options:
-  - U-Bahn: U
-  - Bus: Bus
-  - Tram: T
-  - S-Bahn: S
-  multiple: true
-  optional: true
+  - keyname: stopId
+    field_type: string
+    name: Stop ID
+    description: Stop ID from the BVG API.
+    help_text: The Stop ID can be found using the <a href="link-to-api" target="https://v6.bvg.transport.rest/api.html#get-locations" class="underline">locations endpoint</a> of the BVG API.
+    default: 900100003
+  - keyname: modes
+    field_type: select
+    name: Preferred Transport Modes
+    help_text: Select which types of transport to show.<br>Hold cmd(⌘) or ctrl to choose multiple options.
+    options:
+      - U-Bahn: U
+      - Bus: B
+      - Tram: T
+      - S-Bahn: S
+    multiple: true
+    optional: true
 name: BVG - Berlin Public Transport
 refresh_interval: 15

--- a/shared.liquid
+++ b/shared.liquid
@@ -1,0 +1,40 @@
+{% template full_header %}
+<thead>
+  <tr>
+    <th><span class="label label--bold">Time</span></th>
+    <th><span class="label label--bold">Direction</span></th>
+    <th><span class="label label--bold">Plat</span></th>
+    <th><span class="label label--bold">Note</span></th>
+    <th><span class="label label--bold">Delay</span></th>
+    <th><span class="label label--bold">Line</span></th>
+  </tr>
+</thead>
+{% endtemplate %}
+
+{% template half_header %}
+<thead>
+  <tr>
+    <th><span class="label label--small">Time</span></th>
+    <th><span class="label label--small">Direction</span></th>
+    <th><span class="label label--small">Line</span></th>
+  </tr>
+</thead>
+{% endtemplate %}
+
+{% template start_loop %}
+    {% assign count = 0 %}
+    {% for item in departures %}
+    {% assign mode = item.line.productName | slice: 0 %}
+    {% if preferred_modes_raw contains mode %}
+    {% assign delay_minutes = item.delay | divided_by: 60 %}
+    {% assign count = count | plus: 1 %}
+{% endtemplate %}
+
+
+{% template end_loop %}
+{% endif %}
+{% if count == {{count}} %}
+    {% break %}
+{% endif %}
+{% endfor %}
+{% endtemplate %}


### PR DESCRIPTION
I got the trmnl today and was very happy to see that there was a plugin already for BVG. I saw that the trams were not showing up so I fixed that and ended up doing a few small improvements.

Let me know if you want me to change anything!

List of stuff that was done

1. fix trams not showing up due to naming.
2. changed filtering to work on first letter of the product name
3. use counts + breaks instead of limits in for loop to fill up space if stuff is filtered out
4. add cancelled to delay display
5. fix tram icon not showing
6. move some common stuff to shared
7. show cancelled in vertical and quadrant displays
8. show warnings as notes